### PR TITLE
Better translation of enabled and disabled

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -117,9 +117,9 @@ core:
     # These translations are used on default extension pages.
     extension:
       confirm_uninstall: Odinstalováním se smažou všechny záznamy v databázi a soubory související s rozšířením. Opravdu chceš pokračovat?
-      disabled: Deaktivovat
-      enabled: Povolit
-      enable_to_see: Povolit rozšíření zobrazovat a měnit nastavení.
+      disabled: Neaktivní
+      enabled: Aktivní
+      enable_to_see: Povolit zobrazovat rozšíření a měnit nastavení.
       info_links:
         discuss: Discuss
         documentation: Dokumentace


### PR DESCRIPTION
Current translation of enabled and disabled is not really fitting, so I change it to hopefully better alternative.
Current version:
![image](https://user-images.githubusercontent.com/1169782/119038052-fb844900-b9b2-11eb-8932-bbd783fd64f4.png)
![image](https://user-images.githubusercontent.com/1169782/119038106-063ede00-b9b3-11eb-866f-f047e8dc2161.png)
